### PR TITLE
Strip question marks from sql segment names.

### DIFF
--- a/src/Collectors/Backtracer.php
+++ b/src/Collectors/Backtracer.php
@@ -23,8 +23,9 @@ trait Backtracer
     public function getCallerClass(array $backtrace): string
     {
         $arr = explode('\\', $backtrace[0]);
-
-        return end($arr);
+        $callerString = end($arr);
+        $cleanCallerString = str_replace(':?', '', $callerString);
+        return $cleanCallerString;
     }
 
     protected function parseTrace($index, array $trace)

--- a/src/Collectors/Backtracer.php
+++ b/src/Collectors/Backtracer.php
@@ -25,6 +25,7 @@ trait Backtracer
         $arr = explode('\\', $backtrace[0]);
         $callerString = end($arr);
         $cleanCallerString = str_replace(':?', '', $callerString);
+
         return $cleanCallerString;
     }
 


### PR DESCRIPTION
I was unable to submit segment names for MySQL when the caller class trace had a question mark such as `ClassName:?`. This just strips the `:?` when it is present.