### PR TITLE
Make all parts of AWS config configurable

### DIFF
--- a/config/xray.php
+++ b/config/xray.php
@@ -50,7 +50,7 @@ return [
             'key' => env('AWS_XRAY_ACCESS_KEY_ID') ?? env('AWS_ACCESS_KEY_ID'),
             'secret' => env('AWS_XRAY_SECRET_ACCESS_KEY') ?? env('AWS_SECRET_ACCESS_KEY'),
             'token' => env('AWS_XRAY_TOKEN'),
-            'expires' => now()->addDay()->unix()
+            'expires' => now()->addDay()->unix(),
         ],
     ],
 ];

--- a/config/xray.php
+++ b/config/xray.php
@@ -43,8 +43,14 @@ return [
     |--------------------------------------------------------------------------
     */
     'aws' => [
-        'key' => env('AWS_ACCESS_KEY_ID'),
-        'secret' => env('AWS_SECRET_ACCESS_KEY'),
-        'region' => env('AWS_DEFAULT_REGION'),
+        'region' => env('AWS_XRAY_REGION') ?? env('AWS_DEFAULT_REGION'),
+        'version' => env('AWS_XRAY_VERSION', 'latest'),
+        'signature_version' => env('AWS_XRAY_SIGNATURE_VERSION', 'v4'),
+        'credentials' => [
+            'key' => env('AWS_XRAY_ACCESS_KEY_ID') ?? env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_XRAY_SECRET_ACCESS_KEY') ?? env('AWS_SECRET_ACCESS_KEY'),
+            'token' => env('AWS_XRAY_TOKEN'),
+            'expires' => now()->addDay()->unix()
+        ]
     ],
 ];

--- a/config/xray.php
+++ b/config/xray.php
@@ -43,13 +43,13 @@ return [
     |--------------------------------------------------------------------------
     */
     'aws' => [
-        'region' => env('AWS_XRAY_REGION') ?? env('AWS_DEFAULT_REGION'),
-        'version' => env('AWS_XRAY_VERSION', 'latest'),
-        'signature_version' => env('AWS_XRAY_SIGNATURE_VERSION', 'v4'),
+        'region' => env('XRAY_AWS_REGION') ?? env('AWS_DEFAULT_REGION'),
+        'version' => env('XRAY_AWS_VERSION', 'latest'),
+        'signature_version' => env('XRAY_AWS_SIGNATURE_VERSION', 'v4'),
         'credentials' => [
-            'key' => env('AWS_XRAY_ACCESS_KEY_ID') ?? env('AWS_ACCESS_KEY_ID'),
-            'secret' => env('AWS_XRAY_SECRET_ACCESS_KEY') ?? env('AWS_SECRET_ACCESS_KEY'),
-            'token' => env('AWS_XRAY_TOKEN'),
+            'key' => env('XRAY_AWS_ACCESS_KEY_ID') ?? env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('XRAY_AWS_SECRET_ACCESS_KEY') ?? env('AWS_SECRET_ACCESS_KEY'),
+            'token' => env('XRAY_AWS_TOKEN'),
             'expires' => now()->addDay()->unix(),
         ],
     ],

--- a/config/xray.php
+++ b/config/xray.php
@@ -51,6 +51,6 @@ return [
             'secret' => env('AWS_XRAY_SECRET_ACCESS_KEY') ?? env('AWS_SECRET_ACCESS_KEY'),
             'token' => env('AWS_XRAY_TOKEN'),
             'expires' => now()->addDay()->unix()
-        ]
+        ],
     ],
 ];

--- a/src/Submission/APISegmentSubmitter.php
+++ b/src/Submission/APISegmentSubmitter.php
@@ -17,17 +17,7 @@ class APISegmentSubmitter implements SegmentSubmitter
 
     public function __construct()
     {
-        $this->client = new XRayClient([
-            'region' => config('xray.aws.region'),
-            'version' => 'latest',
-            'signature_version' => 'v4',
-            'credentials' => new \Aws\Credentials\Credentials(
-                config('xray.aws.key'),
-                config('xray.aws.secret'),
-                null,
-                now()->addDay()->unix()
-            ),
-        ]);
+        $this->client = new XRayClient(config('xray.aws'));
     }
 
     public function submitSegment(Segment $segment)


### PR DESCRIPTION
In the current design, it is not possible to separate your default AWS config from the Xray specific config. This commit allows that. It also moves all the configuration out of the APISegmentSubmitter class into the config file, which allows for setting values to null, and therefore defaulting to the local running instances IAM role permissions. This is needed if you are running an ECS task with an IAM role that controls the Xray access.