### PR TITLE
Fix Database Query Segment Invalid Segment Names

### DIFF
--- a/src/Collectors/Backtracer.php
+++ b/src/Collectors/Backtracer.php
@@ -30,7 +30,7 @@ trait Backtracer
     protected function parseTrace($index, array $trace)
     {
         if (isset($trace['class']) && ! $this->isExcludedClass($trace['class'])) {
-            return $trace['class'] . ':' . ($trace['line'] ?? '?');
+            return $trace['class'] . ':' . ($trace['line'] ?? '');
         }
 
         return '';


### PR DESCRIPTION
#29 

Replaces the ? being sent in Database query segments with an empty string