### PR TITLE
Fix User Not Sent in Traces

### DIFF
--- a/src/Collectors/SegmentCollector.php
+++ b/src/Collectors/SegmentCollector.php
@@ -127,7 +127,7 @@ class SegmentCollector
         $submitterClass = config('xray.submitter');
         $tracer = $this->tracer();
 
-        if (app()->bound(Auth::class) && Auth::check()) {
+        if (app()->bound('auth') && Auth::check()) {
             $tracer->setUser((string) Auth::user()->getAuthIdentifier());
         }
         $tracer->end()


### PR DESCRIPTION
Fixes incorrect condition to check if Auth is enabled.

The current statement would always return false even if the standard Auth module is enabled. This caused the current user identifier to never be included in traces.

I changed this to correctly check if Auth is being used or not.