### PR TITLE
Tracer can use custom resolver for sending logged-in user ID

### DIFF
--- a/config/xray.php
+++ b/config/xray.php
@@ -18,6 +18,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | User resolver method
+    |--------------------------------------------------------------------------
+    |
+    | Here you can set a class to find the logged-in user identifier.
+    | Supported classes: "AuthIdentifier"
+    |
+    */
+    'user-resolver' => \Napp\Xray\Resolvers\AuthIdentifier::class,
+
+    /*
+    |--------------------------------------------------------------------------
     | Enable Database Query
     |--------------------------------------------------------------------------
     */

--- a/src/Resolvers/AuthIdentifier.php
+++ b/src/Resolvers/AuthIdentifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Napp\Xray\Resolvers;
+
+use Illuminate\Support\Facades\Auth;
+use Napp\Xray\Resolvers\Contracts\ResolvesUser;
+
+class AuthIdentifier implements ResolvesUser
+{
+    public function getUser(): ?string
+    {
+        if (app()->bound('auth') && Auth::check()) {
+            return (string) Auth::user()->getAuthIdentifier();
+        }
+
+        return null;
+    }
+}

--- a/src/Resolvers/Contracts/ResolvesUser.php
+++ b/src/Resolvers/Contracts/ResolvesUser.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Napp\Xray\Resolvers\Contracts;
+
+interface ResolvesUser
+{
+    public function getUser(): ?string;
+}

--- a/tests/SegmentCollectorTest.php
+++ b/tests/SegmentCollectorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Napp\Xray\Tests;
+
+use Illuminate\Support\Facades\Auth;
+use Napp\Xray\Tests\Stubs\CustomUserResolver;
+use Napp\Xray\Tests\Stubs\User;
+use Napp\Xray\Collectors\SegmentCollector;
+use Napp\Xray\XrayServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class SegmentCollectorTest extends TestCase
+{
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     * @return string[]
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            XrayServiceProvider::class,
+        ];
+    }
+
+    public function test_get_user_when_logged_in()
+    {
+        Auth::login(new User());
+
+        $collector = new SegmentCollector();
+
+        $this->assertSame('1', $collector->getUser());
+    }
+
+    public function test_get_user_when_guest()
+    {
+        $collector = new SegmentCollector();
+
+        $this->assertNull($collector->getUser());
+    }
+
+    public function test_get_user_when_config_is_missing()
+    {
+        $config = config('xray');
+        unset($config['user-resolver']);
+        config()->set('xray', $config);
+
+        Auth::login(new User());
+
+        $collector = new SegmentCollector();
+
+        $this->assertSame('1', $collector->getUser());
+    }
+
+    public function test_get_user_when_custom_resolver_is_configured()
+    {
+        config()->set('xray.user-resolver', CustomUserResolver::class);
+
+        $collector = new SegmentCollector();
+
+        $this->assertSame('foo', $collector->getUser());
+    }
+}

--- a/tests/Stubs/CustomUserResolver.php
+++ b/tests/Stubs/CustomUserResolver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Napp\Xray\Tests\Stubs;
+
+use Napp\Xray\Resolvers\Contracts\ResolvesUser;
+
+class CustomUserResolver implements ResolvesUser
+{
+    public function getUser(): ?string
+    {
+        return 'foo';
+    }
+}

--- a/tests/Stubs/User.php
+++ b/tests/Stubs/User.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Napp\Xray\Tests\Stubs;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class User implements Authenticatable
+{
+    public function getAuthIdentifierName(): string
+    {
+        return 'id';
+    }
+
+    public function getAuthIdentifier(): int
+    {
+        return 1;
+    }
+
+    public function getAuthPassword(): string
+    {
+        return 'foo';
+    }
+
+    public function getRememberToken(): string
+    {
+        return 'bar';
+    }
+
+    public function setRememberToken($value): void
+    {
+    }
+
+    public function getRememberTokenName(): string
+    {
+        return 'baz';
+    }
+}


### PR DESCRIPTION
## Summary

https://github.com/Napp/xray-laravel/pull/8 & https://github.com/Napp/xray-laravel/pull/31 follow-up

### config/xray.php

```
/*
|--------------------------------------------------------------------------
| User resolver method
|--------------------------------------------------------------------------
|
| Here you can set a class to find the logged-in user identifier.
| Supported classes: "AuthIdentifier"
|
*/
'user-resolver' => \Napp\Xray\Resolvers\AuthIdentifier::class,
```

Allow changing new key `config('xray.user-resolver')` with a custom class defining `getUser()` that will return a string for identifying a logged in user.

---

This allows:

1. a custom `Auth::guard('name')` other than `config('auth.defaults.guard')`
2. a custom `Auth::user()->getAttribute()` other than `getAuthIdentifier()`, such as `$user->uuid` instead of `$user->id`.
3. use a request parameter or header and never use the Auth service
4. `null` in the new config key to never track the user ID in traces
   * existing installs will continue sending `Auth::user()->getAuthIdentifier()` until file config/xray.php is updated with the new key:

     ```
     return [
          'submitter' => \Napp\Xray\Submission\APISegmentSubmitter::class,
          'user-resolver' => null,
          'db_query' => env('XRAY_DB_QUERY', true),
          // etc.
      ];
      ```
5. suppress `InvalidArgumentException` that Laravel's `AuthManager::resolve()` can throw if the guard isn't yet configured despite `app()->bound('auth') === true`.
   * This can occur if an exception is thrown while booting the framework immediately after `'auth'` is bound to Laravel's app container. An exception in this package's `RequestTracing::terminate()` callback will be reported to Sentry, Bugsnag, Rollbar, etc. rather than the original exception.