### PR TITLE
Adding fallback to AWS_SESSION_TOKEN inside the config

### DIFF
--- a/config/xray.php
+++ b/config/xray.php
@@ -88,7 +88,7 @@ return [
         'credentials' => [
             'key' => env('XRAY_AWS_ACCESS_KEY_ID') ?? env('AWS_ACCESS_KEY_ID'),
             'secret' => env('XRAY_AWS_SECRET_ACCESS_KEY') ?? env('AWS_SECRET_ACCESS_KEY'),
-            'token' => env('XRAY_AWS_TOKEN'),
+            'token' => env('XRAY_AWS_TOKEN') ?? env('AWS_SESSION_TOKEN'),
             'expires' => '',
         ],
     ],


### PR DESCRIPTION
Using Bref + Laravel: Without this the PutTelemetryRecords API fails with "missing security token"