### PR TITLE
Use LAMBDA_INVOCATION_CONTEXT instead of HTTP_X_AMZN_TRACE_ID

### DIFF
--- a/config/xray.php
+++ b/config/xray.php
@@ -14,7 +14,7 @@ return [
     | Supported classes: "APISegmentSubmitter", "DaemonSegmentSubmitter"
     |
     */
-    'submitter' => \Napp\Xray\Submission\DaemonSegmentSubmitter::class,
+    'submitter' => \Napp\Xray\Submission\APISegmentSubmitter::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/xray.php
+++ b/config/xray.php
@@ -81,7 +81,7 @@ return [
     | Use LAMBDA_INVOCATION_CONTEXT
     |--------------------------------------------------------------------------
     */
-    'use_lambda_invocation_context' => env('XRAY_USE_LAMBDA_INVOCATION_CONTEXT', true),
+    'use_lambda_invocation_context' => env('XRAY_USE_LAMBDA_INVOCATION_CONTEXT', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/xray.php
+++ b/config/xray.php
@@ -14,7 +14,7 @@ return [
     | Supported classes: "APISegmentSubmitter", "DaemonSegmentSubmitter"
     |
     */
-    'submitter' => \Napp\Xray\Submission\APISegmentSubmitter::class,
+    'submitter' => \Napp\Xray\Submission\DaemonSegmentSubmitter::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -75,6 +75,13 @@ return [
     |--------------------------------------------------------------------------
     */
     'cache' => env('XRAY_CACHE', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Use LAMBDA_INVOCATION_CONTEXT
+    |--------------------------------------------------------------------------
+    */
+    'use_lambda_invocation_context' => env('XRAY_USE_LAMBDA_INVOCATION_CONTEXT', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Collectors/SegmentCollector.php
+++ b/src/Collectors/SegmentCollector.php
@@ -38,9 +38,15 @@ class SegmentCollector
             return;
         }
 
+        $traceId = json_decode($_SERVER['HTTP_X_AMZN_TRACE_ID'] ?? null);
+        
+        if ((bool) config('xray.enabled')) {
+            $traceId = json_decode($_SERVER['LAMBDA_INVOCATION_CONTEXT'])->traceId ?? NULL;
+        }
+
         $this->segments = [];
         $tracer = $this->tracer()
-            ->setTraceHeader($_SERVER['HTTP_X_AMZN_TRACE_ID'] ?? null)
+            ->setTraceHeader($traceId)
             ->setName(config('app.name') . ' HTTP')
             ->setClientIpAddress($request->getClientIp())
             ->addAnnotation('Framework', 'Laravel ' . app()->version())

--- a/src/Collectors/SegmentCollector.php
+++ b/src/Collectors/SegmentCollector.php
@@ -38,7 +38,7 @@ class SegmentCollector
             return;
         }
 
-        $traceId = json_decode($_SERVER['HTTP_X_AMZN_TRACE_ID'] ?? null);
+        $traceId = $_SERVER['HTTP_X_AMZN_TRACE_ID'] ?? null;
         
         if ((bool) config('xray.enabled')) {
             $traceId = json_decode($_SERVER['LAMBDA_INVOCATION_CONTEXT'])->traceId ?? NULL;

--- a/src/Collectors/SegmentCollector.php
+++ b/src/Collectors/SegmentCollector.php
@@ -40,7 +40,7 @@ class SegmentCollector
 
         $traceId = $_SERVER['HTTP_X_AMZN_TRACE_ID'] ?? null;
         
-        if ((bool) config('xray.enabled')) {
+        if ((bool) config('xray.use_lambda_invocation_context')) {
             $traceId = json_decode($_SERVER['LAMBDA_INVOCATION_CONTEXT'])->traceId ?? NULL;
         }
 

--- a/src/Collectors/SegmentCollector.php
+++ b/src/Collectors/SegmentCollector.php
@@ -39,9 +39,9 @@ class SegmentCollector
         }
 
         $traceId = $_SERVER['HTTP_X_AMZN_TRACE_ID'] ?? null;
-        
+
         if ((bool) config('xray.use_lambda_invocation_context')) {
-            $traceId = json_decode($_SERVER['LAMBDA_INVOCATION_CONTEXT'])->traceId ?? NULL;
+            $traceId = json_decode($_SERVER['LAMBDA_INVOCATION_CONTEXT'])->traceId ?? null;
         }
 
         $this->segments = [];


### PR DESCRIPTION
With HTTP_X_AMZN_TRACE_ID

<img width="558" alt="image" src="https://user-images.githubusercontent.com/1665768/229477767-c078239e-a509-4bd1-8544-7f5ba9f2578e.png">
<img width="632" alt="image" src="https://user-images.githubusercontent.com/1665768/229477789-0ee26e32-3b6f-4ee1-9e16-bf72b4eaf6d6.png">

With LAMBDA_INVOCATION_CONTEXT

<img width="669" alt="image" src="https://user-images.githubusercontent.com/1665768/229477097-ff52f054-db5f-47d7-be0e-6b195b867a36.png">

This is because HTTP_X_AMZN_TRACE_ID doesn't contain the parent ID

<img width="537" alt="image" src="https://user-images.githubusercontent.com/1665768/229477881-4026c75d-1c49-438f-a754-2146708a9df7.png">
vs
<img width="699" alt="image" src="https://user-images.githubusercontent.com/1665768/229477940-87f024bc-770d-4c5d-a8cf-e493c9c611da.png">
