### PR TITLE
[BUGFIX] #36 Added fallback when backtrace does not contain caller name

### DIFF
--- a/src/Collectors/Backtracer.php
+++ b/src/Collectors/Backtracer.php
@@ -22,7 +22,7 @@ trait Backtracer
 
     public function getCallerClass(array $backtrace): ?string
     {
-        if(sizeof($backtrace) === 0) {
+        if (sizeof($backtrace) === 0) {
             return null;
         }
 

--- a/src/Collectors/Backtracer.php
+++ b/src/Collectors/Backtracer.php
@@ -20,8 +20,12 @@ trait Backtracer
         return array_slice(array_filter($sources), 0, 10);
     }
 
-    public function getCallerClass(array $backtrace): string
+    public function getCallerClass(array $backtrace): ?string
     {
+        if(sizeof($backtrace) === 0) {
+            return null;
+        }
+
         $arr = explode('\\', $backtrace[0]);
 
         return end($arr);

--- a/src/Collectors/CacheCollector.php
+++ b/src/Collectors/CacheCollector.php
@@ -35,7 +35,7 @@ class CacheCollector extends EventsCollector
     {
         $backtrace = $this->getBacktrace();
 
-        $eventSuffix = sizeof($backtrace) > 0 ? ('at ' . $this->getCallerClass($backtrace)) : "(too deeply nested)";
+        $eventSuffix = sizeof($backtrace) > 0 ? ('at ' . $this->getCallerClass($backtrace)) : '(too deeply nested)';
 
         $this
             ->addSegment("$eventName $eventSuffix")

--- a/src/Collectors/CacheCollector.php
+++ b/src/Collectors/CacheCollector.php
@@ -34,8 +34,11 @@ class CacheCollector extends EventsCollector
     protected function handleQueryReport(string $cacheKey, string $eventName): void
     {
         $backtrace = $this->getBacktrace();
+
+        $eventSuffix = sizeof($backtrace) > 0 ? ('at ' . $this->getCallerClass($backtrace)) : "(too deeply nested)";
+
         $this
-            ->addSegment($eventName . ' at ' . $this->getCallerClass($backtrace))
+            ->addSegment("$eventName $eventSuffix")
             ->addAnnotation('Key', $cacheKey)
             ->addMetadata('backtrace', $backtrace)
             ->end();

--- a/src/Collectors/DatabaseQueryCollector.php
+++ b/src/Collectors/DatabaseQueryCollector.php
@@ -20,7 +20,7 @@ class DatabaseQueryCollector extends EventsCollector
             $this->handleQueryReport($sql, $query->bindings, $query->time, $query->connection);
         });
 
-        $this->bindingsEnabled = config('xray.db_bindings');
+        $this->checkForEnabledBindings();
     }
 
     protected function handleQueryReport(string $sql, array $bindings, float $time, Connection $connection): void
@@ -30,15 +30,22 @@ class DatabaseQueryCollector extends EventsCollector
         }
 
         $backtrace = $this->getBacktrace();
+
+        $eventSuffix = sizeof($backtrace) > 0 ? ('at ' . $this->getCallerClass($backtrace)) : '(too deeply nested)';
+
         $this->current()->addSubsegment(
             (new SqlSegment())
-                ->setName($connection->getName() . ' at ' . $this->getCallerClass($backtrace))
+                ->setName($connection->getName() . " " . $eventSuffix)
                 ->setDatabaseType($connection->getDriverName())
                 ->setQuery($sql)
                 ->addMetadata('backtrace', $backtrace)
                 ->begin()
                 ->end($time / 1000)
         );
+    }
+
+    protected function checkForEnabledBindings(): void {
+        $this->bindingsEnabled = config('xray.db_bindings');
     }
 
     private function parseBindings(string $sql, array $bindings, Connection $connection): string

--- a/src/Collectors/DatabaseQueryCollector.php
+++ b/src/Collectors/DatabaseQueryCollector.php
@@ -35,7 +35,7 @@ class DatabaseQueryCollector extends EventsCollector
 
         $this->current()->addSubsegment(
             (new SqlSegment())
-                ->setName($connection->getName() . " " . $eventSuffix)
+                ->setName($connection->getName() . ' ' . $eventSuffix)
                 ->setDatabaseType($connection->getDriverName())
                 ->setQuery($sql)
                 ->addMetadata('backtrace', $backtrace)
@@ -44,7 +44,8 @@ class DatabaseQueryCollector extends EventsCollector
         );
     }
 
-    protected function checkForEnabledBindings(): void {
+    protected function checkForEnabledBindings(): void
+    {
         $this->bindingsEnabled = config('xray.db_bindings');
     }
 

--- a/tests/Collectors/BacktracerTest.php
+++ b/tests/Collectors/BacktracerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Napp\Xray\Tests\Collectors;
+
+use Napp\Xray\Collectors\Backtracer;
+use PHPUnit\Framework\TestCase;
+class BacktracerTest extends TestCase
+{
+    public function test_it_should_not_crash_when_backtrace_is_empty() {
+        // given a segment that implements the Backtracer trait
+        $implementationClass = new class {
+            use Backtracer;
+
+            // and an override of the `getBacktrace` function to return an empty array
+            public function getBacktrace(): array
+            {
+                return [];
+            }
+
+            // and a function that calls the `getCallerClass` function
+            public function getResult() {
+                $backtrace = $this->getBacktrace();
+
+                return $this->getCallerClass($backtrace);
+            }
+        };
+
+        // when calling the getResult class on the implementation
+        $result = $implementationClass->getResult();
+
+        // then it should return null
+        $this->assertNull($result);
+    }
+}

--- a/tests/Collectors/CacheCollectorTest.php
+++ b/tests/Collectors/CacheCollectorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Napp\Xray\Tests\Collectors;
+
+use Illuminate\Cache\Events\CacheHit;
+use Monolog\Test\TestCase;
+use \Illuminate\Foundation\Application;
+use Napp\Xray\Collectors\CacheCollector;
+use Pkerrigan\Xray\Segment;
+
+class CacheCollectorTest extends TestCase
+{
+    public function test_it_should_handle_null_callerClass() {
+        // given a mock implementation of the Application Object
+        $mockApplication = new CacheCollectorTestMockApplication();
+
+        // given a CacheCollector object
+        $cacheCollectorMock = new class($mockApplication) extends CacheCollector {
+            // and an overridden getBacktrace function that returns an empty array
+            public function getBacktrace(): array
+            {
+                return [];
+            }
+
+            // and a custom public function that returns the segments
+            public function getSegments(): array {
+                return $this->segments;
+            }
+        };
+
+        // and an event for this cacheCollectorMock
+        $givenEvent = new CacheHit("irrelevent", "irrelevent");
+
+        // when dispatching the event on the mock application
+        $mockApplication->events->dispatch($givenEvent);
+
+        // then a segment should have been dispatched
+        $this->assertCount(1, $cacheCollectorMock->getSegments());
+
+        // and the segment name should contain "too deeply nested"
+        /** @var Segment $firstSegment */
+        $firstSegment = array_values($cacheCollectorMock->getSegments())[0];
+        $firstSegmentData = $firstSegment->jsonSerialize();
+
+        $this->assertStringContainsString("too deeply nested", $firstSegmentData['name']);
+        $this->assertStringNotContainsString(" at ", $firstSegmentData['name']);
+    }
+}
+
+class CacheCollectorTestMockApplication extends Application {
+
+    public $events;
+    public function __construct()
+    {
+        $this->events = new CacheCollectorTestMockEvents();
+    }
+}
+
+class CacheCollectorTestMockEvents {
+    protected $listeners = [];
+
+    public function listen(string $event, $callback) {
+        $this->listeners[$event] = $callback;
+    }
+
+    public function dispatch($eventObject) {
+        $eventClass = get_class($eventObject);
+
+        if(!array_key_exists($eventClass, $this->listeners)) {
+            throw new \Exception("Unit test exception, $eventClass was never registered");
+        }
+
+        $eventCallback = $this->listeners[$eventClass];
+
+        $eventCallback($eventObject);
+    }
+}

--- a/tests/Collectors/DatabaseQueryCollectorTest.php
+++ b/tests/Collectors/DatabaseQueryCollectorTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Napp\Xray\Tests\Collectors;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Application;
+use Napp\Xray\Collectors\DatabaseQueryCollector;
+use PHPUnit\Framework\TestCase;
+use Pkerrigan\Xray\Segment;
+
+class DatabaseQueryCollectorTest extends TestCase
+{
+    public function test_it_should_handle_null_callerClass()
+    {
+        // given a mock implementation of the Application Object
+        $mockApplication = new DatabaseQueryCollectorTestMockApplication();
+
+
+        // given a DatabaseQueryCollector object
+        $databaseQueryCollectorMock = new class($mockApplication) extends DatabaseQueryCollector {
+            protected $currentSegment;
+            // and an overridden getBacktrace function that returns an empty array
+            public function getBacktrace(): array
+            {
+                return [];
+            }
+
+            protected function checkForEnabledBindings(): void {}
+
+            // and a defined current segment
+            public function current(): Segment
+            {
+                if(is_null($this->currentSegment)) {
+                    $this->currentSegment = new Segment();
+                    $this->currentSegment->begin();
+                }
+
+                return $this->currentSegment;
+            }
+        };
+
+        // and an event for this DatabaseQueryCollectorMock
+        $connectionMock = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connectionMock->method('getName')
+            ->willReturn('irrelevent');
+
+        $connectionMock->method('getDriverName')
+            ->willReturn('irrelevent');
+
+        $givenEvent = new QueryExecuted("irrelevent", [], 1000, $connectionMock);
+
+        // when dispatching the event on the mock application
+        $mockApplication->events->dispatch($givenEvent);
+
+        // then a sub segment should have been dispatched
+        $currentSegment = $databaseQueryCollectorMock->current();
+        $currentSegmentData = $currentSegment->jsonSerialize();
+
+        $this->assertCount(1, $currentSegmentData['subsegments']);
+
+        // and the sub segment name should contain "too deeply nested"
+        /** @var Segment $firstSubSegment */
+        $firstSubSegment = $currentSegmentData['subsegments'][0];
+        $firstSubSegmentData = $firstSubSegment->jsonSerialize();
+
+        $this->assertStringContainsString("too deeply nested", $firstSubSegmentData['name']);
+        $this->assertStringNotContainsString(" at ", $firstSubSegmentData['name']);
+    }
+}
+
+class DatabaseQueryCollectorTestMockApplication extends Application
+{
+
+    public $events;
+
+    public function __construct()
+    {
+        $this->events = new DatabaseQueryCollectorTestMockEvents();
+    }
+}
+
+class DatabaseQueryCollectorTestMockEvents
+{
+    protected $listeners = [];
+
+    public function listen(string $event, $callback)
+    {
+        $this->listeners[$event] = $callback;
+    }
+
+    public function dispatch($eventObject)
+    {
+        $eventClass = get_class($eventObject);
+
+        if (!array_key_exists($eventClass, $this->listeners)) {
+            throw new \Exception("Unit test exception, $eventClass was never registered");
+        }
+
+        $eventCallback = $this->listeners[$eventClass];
+
+        $eventCallback($eventObject);
+    }
+}


### PR DESCRIPTION
### Summary
Fixed bug where the `getCallerClass` function would throw an exception, when the `getBacktrace` function returns an empty array. This occurs when the caller is deeper than 50 level in the backtrace. 

In this case, I've added the suffix `(too deeply nested)` to the segment, which indicate that the caller could not be found.

I've envisaged making the backtrace count configurable, however, there will always have a case where the caller is deeper than 50 levels, when eager loading relation. This changes prevent the code from crashing in this case. We could still add a config to change the number of backtrace we want to fetch, but for now, this change will work fine.

### Other changes.
I've move the code that check if bindings should be enabled, in it's own function. This decouple de config from the event registering function and allow us to override the function. This was necessary, because the `config` function was not working properly without having a complete laravel installation. It, also, open the door to extension, in the even that we want to change the behaviour of this function by extending the class. 

I've added test cases for every file that was changed.

Fixes #36 

### Steps to tests.
1) Create a structure of deeply nested relations.
2) attempt to eager load all of the deeply nested relation,
3) The code should not crash if the backtrace only contain excluded classes.

