### PR TITLE
Add daemon configuration to the config file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "napp/xray-laravel",
+    "name": "jonsutherland/xray-laravel",
     "description": "AWS X-Ray for Laravel applications.",
     "keywords": [
         "xray",

--- a/config/xray.php
+++ b/config/xray.php
@@ -106,4 +106,14 @@ return [
             'expires' => '',
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Daemon, only needed if "DaemonSegmentSubmitter" submitter is chosen
+    |--------------------------------------------------------------------------
+    */
+    'daemon' => [
+	    'address' => env('_AWS_XRAY_DAEMON_ADDRESS', '127.0.0.1'),
+	    'port' => env('_AWS_XRAY_DAEMON_PORT', '2000')
+    ],
 ];

--- a/src/Submission/DaemonSegmentSubmitter.php
+++ b/src/Submission/DaemonSegmentSubmitter.php
@@ -27,8 +27,8 @@ class DaemonSegmentSubmitter implements SegmentSubmitter
 
     public function __construct()
     {
-        $this->host = env('_AWS_XRAY_DAEMON_ADDRESS');
-        $this->port = (int) env('_AWS_XRAY_DAEMON_PORT');
+        $this->host = config('xray.daemon.address');
+        $this->port = (int) config('xray.daemon.port');
     }
 
     /**


### PR DESCRIPTION
Use config() rather than env() for DaemonSegmentSubmitter to fix issues with laravel `php artisan optimize` when env() used outside of config files it breaks when the env in not a system set environment variable and just set in the .env file.

Also sets defaults which makes it easier, not requiring users to set _AWS_XRAY_DAEMON environment vars.